### PR TITLE
Limiting number of simultaneous PhantomJS instances

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,12 @@ Default value: `4`
 
 The number of milliseconds when after which the screenshot will be taken.
 
+### options.limit
+Type: `Number`
+Default: Number of CPU cores (`require('os').cpus().length`) with a minimum of 2
+
+Limit of how many PhantomJS instances to run concurrently.
+
 #### [options.paperSize](https://github.com/ariya/phantomjs/wiki/API-Reference-WebPage#wiki-webpage-paperSize)
 
 The `contents` parameter can be a string that will be evaluated, it's necessary if you want to use the `phantom` object.

--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
   "dependencies": {
     "phantomjs": "~1.9.1-0",
     "lodash.assign": "~2.3.0",
-    "lodash.clone": "~2.3.0"
+    "lodash.clone": "~2.3.0",
+    "async": "~0.6.2"
   },
   "devDependencies": {
     "grunt": "~0.4.1"


### PR DESCRIPTION
Thanks for the task: basically works great. I will likely use it as a basis for some other stuff I am working on as well, and may backport things if they seem like they might be useful.

This initial commit makes the command async by default, which seems like a good option rather than discovering a limitation by accident. Hopefully this cleans up #10.

By switching to `grunt.util.spawn`, this can now be used inline with, for example, [grunt-image-resize](/excellenteasy/grunt-image-resize), which can sort of take care of #4.
